### PR TITLE
Puzzle rating UI table

### DIFF
--- a/example_files/fam_fav_puzzles.json
+++ b/example_files/fam_fav_puzzles.json
@@ -1,22 +1,11 @@
 [
   {
-    "name": "Em",
+    "name": "Sarah",
     "puzzles": {
-      "Decaying Diner": 7,
-      "The Mystic Maze": 9,
-      "Hotel Vacancy": 8,
-      "The Crystal Caves": 10,
-      "The Puzzled Patron": 6
-    }
-  },
-  {
-    "name": "Mike",
-    "puzzles": {
-      "Wolves In The Forest": 9,
-      "The Happy Isles": 7,
-      "Sistine Chapel": 8,
-      "The Busy Bistro": 6,
-      "The Forest Feast": 10
+      "Cabinet Of Curiosities": 9,
+      "The Secret Soup": 7,
+      "Cat Tree Heaven": 8,
+      "The Drippy Trip": 6
     }
   },
   {
@@ -30,6 +19,22 @@
     }
   },
   {
+    "name": "New Solver",
+    "puzzles": {
+      "New Puzzle": 6
+    }
+  },
+  {
+    "name": "Em",
+    "puzzles": {
+      "Decaying Diner": 7,
+      "The Mystic Maze": 9,
+      "Hotel Vacancy": 8,
+      "The Crystal Caves": 10,
+      "The Puzzled Patron": 6
+    }
+  },
+  {
     "name": "Laurie",
     "puzzles": {
       "Little Garden World": 7,
@@ -40,13 +45,13 @@
     }
   },
   {
-    "name": "Sarah",
+    "name": "Mike",
     "puzzles": {
-      "Cabinet Of Curiosities": 9,
-      "The Secret Soup": 7,
-      "Cat Tree Heaven": 8,
-      "The Drippy Trip": 6,
-      "Jaws": 10
+      "Wolves In The Forest": 9,
+      "The Happy Isles": 7,
+      "Sistine Chapel": 8,
+      "The Busy Bistro": 6,
+      "The Forest Feast": 10
     }
   }
 ]

--- a/puzzles_app.py
+++ b/puzzles_app.py
@@ -84,6 +84,11 @@ def index():
 def puzzles(request: Request):
     return templates.TemplateResponse("puzzles.html", {"request": request})
 
+@app.get("/puzzles/{puzzle}", response_class=HTMLResponse)
+def puzzle_ratings(puzzle: str, request: Request):
+    puzzle = puzzle.title()
+    return templates.TemplateResponse("puzzle_data.html", {"puzzle": puzzle, "request": request})
+
 
 @app.get("/favicon.ico")
 def favicon():

--- a/templates/puzzle_data.html
+++ b/templates/puzzle_data.html
@@ -1,0 +1,81 @@
+{% extends "base.html" %}
+
+{% block head %}
+{{ super() }}
+{% endblock %}
+
+{% block title %}Puzzles{% endblock %}
+
+{% block content %}
+
+<h1>Ratings for {{ puzzle }}</h1>
+
+<table id="puzzle_ratings" class="display" style="width:100%">
+    <thead>
+        <tr>
+            <th class="all">Solver</th>
+            <th class="all">Rating</th>
+        </tr>
+    </thead>
+</table>
+
+
+<script>
+
+$(document).keypress(function(e) {
+    if (e.keycode == 13 || e.which == 13) {
+        // no buttons expect for positive buttons on modal
+        // have ids: ui primary positive button
+        $('.ui.primary.positive.button').click();
+    }
+});
+
+$(document).ready(function() {
+
+    // let current_puzzle = "{{ puzzle }}";
+    let ratings_table = $('#puzzle_ratings').DataTable({
+        "lengthMenu": [[10, 25, 50, -1], [10, 25, 50, "All"]],
+        "iDisplayLength": -1,
+        "ajax": {
+            "url": "{{ request.url_for('get_puzzle_ratings', puzzle=puzzle) }}",
+            "dataSrc": function(json) {
+                // Convert {puzzle: [ratings]} → array of objects
+                return Object.entries(json).map(([name, rating]) => {
+                    return { solver: name, rating: rating };
+                });
+            }
+        },
+        "columns": [
+            {
+                "data": "solver",
+                "title": "Solver",
+                "width": "80%",
+            },
+            {
+                "data": "rating",
+                "title": "Rating",
+                "width": "20%",
+                // "render": function(data, type, row) {
+                //     if (!data || data.length === 0) return "N/A";
+                //     let avg = data.reduce((a, b) => a + b, 0) / data.length;
+                //     return avg.toFixed(2);
+                // }
+            }//,
+            // {
+            //     "width": "10%",
+            //     "class": "dt-body-left dimmable",
+            //     "render": function(data, type, row) {
+            //         let url = "{{ request.url_for('get_puzzle_ratings', puzzle='PUZZLE') }}".replace('PUZZLE', row.puzzle);
+            //         let res = "<a class='mini ui icon button info-button' href='" + url + "' data-tooltip='See more puzzle info'><i class='search icon'></i></a>";
+            //         return res
+            //     }
+            // }
+        ],
+        "order": [[1, "desc"]],
+    });
+
+})
+
+</script>
+
+{% endblock %}

--- a/templates/puzzle_data.html
+++ b/templates/puzzle_data.html
@@ -22,14 +22,6 @@
 
 <script>
 
-$(document).keypress(function(e) {
-    if (e.keycode == 13 || e.which == 13) {
-        // no buttons expect for positive buttons on modal
-        // have ids: ui primary positive button
-        $('.ui.primary.positive.button').click();
-    }
-});
-
 $(document).ready(function() {
 
     let ratings_table = $('#puzzle_ratings').DataTable({

--- a/templates/puzzle_data.html
+++ b/templates/puzzle_data.html
@@ -32,14 +32,13 @@ $(document).keypress(function(e) {
 
 $(document).ready(function() {
 
-    // let current_puzzle = "{{ puzzle }}";
     let ratings_table = $('#puzzle_ratings').DataTable({
         "lengthMenu": [[10, 25, 50, -1], [10, 25, 50, "All"]],
         "iDisplayLength": -1,
         "ajax": {
             "url": "{{ request.url_for('get_puzzle_ratings', puzzle=puzzle) }}",
             "dataSrc": function(json) {
-                // Convert {puzzle: [ratings]} → array of objects
+                // Convert {name: rating} → array of objects
                 return Object.entries(json).map(([name, rating]) => {
                     return { solver: name, rating: rating };
                 });
@@ -55,21 +54,7 @@ $(document).ready(function() {
                 "data": "rating",
                 "title": "Rating",
                 "width": "20%",
-                // "render": function(data, type, row) {
-                //     if (!data || data.length === 0) return "N/A";
-                //     let avg = data.reduce((a, b) => a + b, 0) / data.length;
-                //     return avg.toFixed(2);
-                // }
-            }//,
-            // {
-            //     "width": "10%",
-            //     "class": "dt-body-left dimmable",
-            //     "render": function(data, type, row) {
-            //         let url = "{{ request.url_for('get_puzzle_ratings', puzzle='PUZZLE') }}".replace('PUZZLE', row.puzzle);
-            //         let res = "<a class='mini ui icon button info-button' href='" + url + "' data-tooltip='See more puzzle info'><i class='search icon'></i></a>";
-            //         return res
-            //     }
-            // }
+            }
         ],
         "order": [[1, "desc"]],
     });

--- a/templates/puzzles.html
+++ b/templates/puzzles.html
@@ -65,7 +65,8 @@ $(document).ready(function() {
                 "width": "10%",
                 "class": "dt-body-left dimmable",
                 "render": function(data, type, row) {
-                    let url = "{{ request.url_for('get_puzzle_ratings', puzzle='PUZZLE') }}".replace('PUZZLE', row.puzzle);
+                    // let url = "{{ request.url_for('get_puzzle_ratings', puzzle='PUZZLE') }}".replace('PUZZLE', row.puzzle);
+                    let url = "{{ request.url_for('puzzle_ratings', puzzle='PUZZLE') }}".replace('PUZZLE', row.puzzle);
                     let res = "<a class='mini ui icon button info-button' href='" + url + "' data-tooltip='See more puzzle info'><i class='search icon'></i></a>";
                     return res
                 }

--- a/templates/puzzles.html
+++ b/templates/puzzles.html
@@ -65,7 +65,6 @@ $(document).ready(function() {
                 "width": "10%",
                 "class": "dt-body-left dimmable",
                 "render": function(data, type, row) {
-                    // let url = "{{ request.url_for('get_puzzle_ratings', puzzle='PUZZLE') }}".replace('PUZZLE', row.puzzle);
                     let url = "{{ request.url_for('puzzle_ratings', puzzle='PUZZLE') }}".replace('PUZZLE', row.puzzle);
                     let res = "<a class='mini ui icon button info-button' href='" + url + "' data-tooltip='See more puzzle info'><i class='search icon'></i></a>";
                     return res

--- a/templates/puzzles.html
+++ b/templates/puzzles.html
@@ -23,14 +23,6 @@
 
 <script>
 
-$(document).keypress(function(e) {
-    if (e.keycode == 13 || e.which == 13) {
-        // no buttons expect for positive buttons on modal
-        // have ids: ui primary positive button
-        $('.ui.primary.positive.button').click();
-    }
-});
-
 $(document).ready(function() {
 
     let puzzle_table = $('#puzzles').DataTable({


### PR DESCRIPTION
Changed redirect of search button click in actions tab of main puzzles table - now redirects to new page with a table showing the people that have rated the puzzle and what rating they gave it. Based on request from @ekukura - 
https://github.com/MelK1221/Puzzles_Project/pull/19#discussion_r2286841214


https://github.com/user-attachments/assets/d4aaef19-e967-4d69-add1-d4771573a6de


All tests remain passing.